### PR TITLE
Bugfix - Using the txt files in the zip archive

### DIFF
--- a/config/replicate.yml
+++ b/config/replicate.yml
@@ -17,7 +17,7 @@ config:
         max_step_saves_to_keep: 1 # how many intermittent saves to keep
       datasets:
         - folder_path: "input_images"
-          caption_ext: "filename"
+          caption_ext: "txt"
           caption_dropout_rate: 0.05  # will drop out the caption 5% of time
           shuffle_tokens: false  # shuffle caption order, split by commas
           cache_latents_to_disk: true  # leave this true unless you know what you're doing


### PR DESCRIPTION
It seems like when I understand your automatic captioning script correctly: https://github.com/fofr/cog-batch-image-captioning
it also puts the captions in the zip. I don't know exactly what is used on replicate, because here are only OAI, Google, ... APIs and on replicate is Llava. 

So there should be the issue for both automatic and manual captioning? 



